### PR TITLE
Rename machine_type.py to physical_or_virtual.py

### DIFF
--- a/facts/physical_or_virtual.py
+++ b/facts/physical_or_virtual.py
@@ -23,4 +23,4 @@ def fact():
     except (IOError, OSError):
         stdout = 'Unknown'
 
-    return {'machine_type': stdout.strip()}
+    return {'physical_or_virtual': stdout.strip()}


### PR DESCRIPTION
Change returned value as well since this breaks the built in munki fact of `machine_type`