### PR TITLE
handle NoneType values - convert to blank strings

### DIFF
--- a/munki_facts.py
+++ b/munki_facts.py
@@ -34,6 +34,11 @@ def main():
             print >> sys.stderr, u'Error %s in file %s' % (err, filename)
 
     if facts:
+        # Handle cases when facts return NoneType or None - convert them to
+        # blank strings.
+        for k, v in facts.items():
+            if v is None or v == 'None':
+                facts[k] = ''
         # Read the location of the ManagedInstallDir from ManagedInstall.plist
         bundle_id = 'ManagedInstalls'
         pref_name = 'ManagedInstallDir'

--- a/munki_facts.py
+++ b/munki_facts.py
@@ -34,10 +34,10 @@ def main():
             print >> sys.stderr, u'Error %s in file %s' % (err, filename)
 
     if facts:
-        # Handle cases when facts return NoneType or None - convert them to
-        # blank strings.
+        # Handle cases when facts return NoneType - convert them to blank
+        # strings.
         for k, v in facts.items():
-            if v is None or v == 'None':
+            if v is None:
                 facts[k] = ''
         # Read the location of the ManagedInstallDir from ManagedInstall.plist
         bundle_id = 'ManagedInstalls'


### PR DESCRIPTION
This is a fix for some facts that could return a NoneType, resulting in a munki-facts trace.

```
Traceback (most recent call last):
  File "/usr/local/munki/conditions/munki_facts.py", line 66, in <module>
    sys.exit(main())
  File "/usr/local/munki/conditions/munki_facts.py", line 60, in main
    plistlib.writePlist(conditional_items, conditionalitemspath)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/plistlib.py", line 94, in writePlist
    writer.writeValue(rootObject)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/plistlib.py", line 252, in writeValue
    self.writeDict(value)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/plistlib.py", line 281, in writeDict
    self.writeValue(value)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/plistlib.py", line 260, in writeValue
    raise TypeError("unsuported type: %s" % type(value))
TypeError: unsuported type: <type 'NoneType'>
```

Also, this slightly changes the behavior of 'None' results. I spoke with @clburlison and we both feel it is better to return a blank string than a string of 'None'