### PR TITLE
add group_memberships, top_user_by_num_logins, top_user_by_connect_time

### DIFF
--- a/facts/group_memberships.py
+++ b/facts/group_memberships.py
@@ -1,0 +1,41 @@
+'''
+modify list of relevant groups in the search_groups list
+and this fact will return any of the groups
+that the top user belongs to.
+
+designed for utilizing munki-conditions to control
+package deployment with active directory groups
+
+by @nathanperkins (GitHub)
+https://github.com/nathanperkins/
+'''
+
+import subprocess
+
+from helpers.users import get_users
+
+search_groups = [
+    # enter group names here
+    'SFO-MacAdmins',
+]
+
+
+def fact():
+    likeliest_user = get_users(sorted_by='connect_time')[0]
+    cmd = ['id', likeliest_user]
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = proc.communicate()
+
+    found_groups = []
+
+    for group in search_groups:
+        if group in out:
+            found_groups.append(group)
+     
+    return {
+        'group_memberships': found_groups,
+    }
+
+if __name__ == '__main__':
+    print fact()

--- a/facts/group_memberships.py
+++ b/facts/group_memberships.py
@@ -12,7 +12,7 @@ https://github.com/nathanperkins/
 
 import subprocess
 
-from helpers.users import get_users
+from facts.helpers.users import get_users
 
 search_groups = [
     # enter group names here

--- a/facts/helpers/users.py
+++ b/facts/helpers/users.py
@@ -1,0 +1,99 @@
+''' 
+helper methods for getting login info and sorting users reported by the ac command
+
+by @nathanperkins
+https://github.com/nathanperkins/
+'''
+
+import sys
+import subprocess
+
+
+def get_users_from_ac():
+    ''' return list of users reported by ac with exclusions removed '''
+
+    exclusions = ['_mbsetupuser', 'root', 'total']
+
+    cmd = ['ac', '-p']
+    proc = subprocess.Popen(
+        cmd, 
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    out, err = proc.communicate()
+
+    output_lines = out.split('\n')
+    users = [line.split()[0].strip() for line in output_lines if len(line) > 0]
+
+    for exclusion in exclusions:
+        if exclusion in users:
+            users.remove(exclusion)
+
+    return users
+
+def get_user_connect_time(ac_output):
+    ''' return the total length of time a user has been connect to a machine based on their ac -d output '''
+    connect_time = 0
+
+    output_lines = [line for line in ac_output.split('\n') if line]
+
+    for line in output_lines:
+        time_connected = float(line.split()[3])
+        if time_connected > 0:
+            connect_time += time_connected
+
+    return connect_time
+
+def get_user_num_logins(ac_output):
+    ''' return the total number of times a user logged in to the machine based on their ac -d output '''
+    output_lines = [line for line in ac_output.split('\n') if line]
+
+    return len(output_lines)
+    
+
+def get_users_info(users):
+    ''' return a list of users with a dict of their connect_time and num_logins '''
+
+    users_info = {}
+
+    for user in users:
+        cmd = ['ac', '-d', user]
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+        out, err = proc.communicate()
+
+        users_info[user] = {
+            'connect_time': get_user_connect_time(out),
+            'num_logins': get_user_num_logins(out),
+        }
+
+    return users_info
+
+def get_users(sorted_by='connect_time'):
+    ''' return a list of users sorted by the given method (connect_time or num_logins) '''
+
+    users = get_users_from_ac()
+    users_info = get_users_info(users)
+
+    if sorted_by == 'connect_time':
+        users = sorted(users_info, key=lambda user: users_info[user]['connect_time'], reverse=True)
+
+    elif sorted_by == 'num_logins':
+        users = sorted(users_info, key=lambda user: users_info[user]['num_logins'], reverse=True)
+
+    else:
+        print("helpers/user.py error: users must be sorted by connect_time or num_logins")
+        sys.exit(1)
+
+    return users
+
+if __name__ == '__main__':
+    users = get_users_from_ac()
+    print('\nget_users_info()\n' + str(get_users_info(users)) + '\n')
+    print("get_users(sorted_by='num_logins')\n" + str(get_users(sorted_by='num_logins')) + '\n')
+    print("get_users(sorted_by='connect_time')\n" + str(get_users(sorted_by='connect_time')) + '\n')

--- a/facts/top_user.py
+++ b/facts/top_user.py
@@ -1,0 +1,17 @@
+'''
+Get top user by number of logins and top user by connect time.
+
+by @nathanperkins (GitHub)
+https://github.com/nathanperkins/
+'''
+
+from helpers.users import get_users
+
+def fact():
+    return {
+        'top_user_by_num_logins': get_users(sorted_by='num_logins')[0],
+        'top_user_by_connect_time': get_users(sorted_by='connect_time')[0],
+    }
+
+if __name__ == '__main__':
+    print fact()

--- a/facts/top_user.py
+++ b/facts/top_user.py
@@ -5,7 +5,7 @@ by @nathanperkins (GitHub)
 https://github.com/nathanperkins/
 '''
 
-from helpers.users import get_users
+from facts.helpers.users import get_users
 
 def fact():
     return {


### PR DESCRIPTION
Not sure if this repo is accepting pull requests or if this might be interesting to other MacAdmins. Feel free to let me know if you'd like me to shift things around or modify anything.

group_memberships:
modify the provided list of search_groups in group_memberships.py and this fact will return any of the groups that contain the top user by connection time. Designed for utilizing munki-conditions to control package deployment with active directory groups.

top_user_by_num_logins:
Get top user by number of logins reported by ac -d command.

top_user_by_connect_time
Get top user by total connect time reported by ac -d command.