### PR TITLE
Add community repos section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ Munki will run `munki_facts.py` and insert any facts it generates into the dicti
 
 Any additional fact modules (that you create or obtain from others) should be copied into the `/usr/local/munki/conditions/facts` directory.
 
+## Community Facts
+
+Community-created facts can be found at the repositories below. 
+
+Running additional facts will increase the time and resources required when managedsoftwarecenter checks in. It is recommended that you only add facts that you intend to use.
+
+Please submit a pull request if you would like to add your munki-facts repo to the list.
+
+| created by | repo | facts |
+| ---------- | ---- | ----------- |
+| [@nathanperkins](https://github.com/nathanperkins/) | [link](https://github.com/n8felton/munki-facts) | top_user_by_connect_time, top_user_by_num_logins, group_memberships |
+| [@vmiller](https://github.com/vmiller) | [link](https://github.com/vmiller/munki-facts) | is_user_logged_in, logged_in_user |


### PR DESCRIPTION
- Wrote a small section on community repos.
- Went through munki-facts forks and found two that had additional facts.
- Formatted community repos as a table.