### PR TITLE
Pin munki-facts to munkipython and remove all pre 3.6 deprecated code

### DIFF
--- a/facts/filevault_status.py
+++ b/facts/filevault_status.py
@@ -14,7 +14,7 @@ def fact():
     except (IOError, OSError):
         stdout = 'Unknown'
 
-    return {'filevault_status': stdout.strip()}
+    return {'filevault_status': stdout.strip().decode('utf-8')}
 
 
 if __name__ == '__main__':

--- a/facts/gatekeeper_status.py
+++ b/facts/gatekeeper_status.py
@@ -14,7 +14,7 @@ def fact():
     except (IOError, OSError):
         stdout = 'Unknown'
 
-    return {'gatekeeper_status': stdout.strip()}
+    return {'gatekeeper_status': stdout.strip().decode('utf-8')}
 
 
 if __name__ == '__main__':

--- a/facts/sip_status.py
+++ b/facts/sip_status.py
@@ -14,7 +14,7 @@ def fact():
     except (IOError, OSError):
         stdout = 'Unknown'
 
-    return {'sip_status': stdout.strip()}
+    return {'sip_status': stdout.strip().decode('utf-8')}
 
 
 if __name__ == '__main__':

--- a/munki_facts.py
+++ b/munki_facts.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 '''Processes python modules in the facts directory and adds the info they
 return to our ConditionalItems.plist'''
 


### PR DESCRIPTION
I've reworked all of the munki-facts code to stop supporting deprecated modules

```
DeprecationWarning: The readPlist function is deprecated, use load() instead

DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses

DeprecationWarning: The writePlist function is deprecated, use dump() instead
```

This will mean that munki-facts will only support python 3.6 and higher, but this will also use munki 4.0's built in python, which uses python 3.7. I think given the upcoming changes to macOS, it would be prudent to make this breaking change now and give people a migration path.