### PR TITLE
Prevent potential `AttributeError` for differing text types.

### DIFF
--- a/facts/filevault_status.py
+++ b/facts/filevault_status.py
@@ -9,12 +9,12 @@ def fact():
     '''Return the current FileVault status for the startup disk'''
     try:
         proc = subprocess.Popen(['/usr/bin/fdesetup', 'status'],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text="UTF-8")
         stdout, _ = proc.communicate()
     except (IOError, OSError):
         stdout = 'Unknown'
 
-    return {'filevault_status': stdout.strip().decode('utf-8')}
+    return {'filevault_status': stdout.strip()}
 
 
 if __name__ == '__main__':

--- a/facts/gatekeeper_status.py
+++ b/facts/gatekeeper_status.py
@@ -9,12 +9,12 @@ def fact():
     '''Return the current Gatekeeper status'''
     try:
         proc = subprocess.Popen(['/usr/sbin/spctl', '--status'],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text="UTF-8")
         stdout, _ = proc.communicate()
     except (IOError, OSError):
         stdout = 'Unknown'
 
-    return {'gatekeeper_status': stdout.strip().decode('utf-8')}
+    return {'gatekeeper_status': stdout.strip()}
 
 
 if __name__ == '__main__':

--- a/facts/sip_status.py
+++ b/facts/sip_status.py
@@ -9,12 +9,12 @@ def fact():
     '''Return the current SIP status for the startup disk'''
     try:
         proc = subprocess.Popen(['/usr/bin/csrutil', 'status'],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text="UTF-8")
         stdout, _ = proc.communicate()
     except (IOError, OSError):
         stdout = 'Unknown'
 
-    return {'sip_status': stdout.strip().decode('utf-8')}
+    return {'sip_status': stdout.strip()}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
During regular execution, the existing code was fine; `stdout` would be
a bytes object, and thus the `decode` method would be available.
However, if the try/except block catches `IOError` or `OSError`, the
assigned `stdout` value is an `str`, which lacks `decode` (it only has
`encode`), and would thus still cause the code to fail.

This change allows `Popen.communicate` to just return str and avoid the later decoding.