### PR TITLE
Updating sysctl function for Python3 compatibility

### DIFF
--- a/facts/bigsur_upgrade_supported.py
+++ b/facts/bigsur_upgrade_supported.py
@@ -58,6 +58,8 @@ def io_key_string_value(keyname):
 
 def sysctl(name, output_type=str):
     '''Wrapper for sysctl so we don't have to use subprocess'''
+    if isinstance(name, str):
+        name = name.encode('utf-8')
     size = c_uint(0)
     # Find out how big our buffer will be
     libc.sysctlbyname(name, None, byref(size), None, 0)

--- a/facts/catalina_upgrade_supported.py
+++ b/facts/catalina_upgrade_supported.py
@@ -52,6 +52,8 @@ def io_key_string_value(keyname):
 
 def sysctl(name, output_type=str):
     '''Wrapper for sysctl so we don't have to use subprocess'''
+    if isinstance(name, str):
+        name = name.encode('utf-8')
     size = c_uint(0)
     # Find out how big our buffer will be
     libc.sysctlbyname(name, None, byref(size), None, 0)

--- a/facts/mojave_upgrade_supported.py
+++ b/facts/mojave_upgrade_supported.py
@@ -52,6 +52,8 @@ def io_key_string_value(keyname):
 
 def sysctl(name, output_type=str):
     '''Wrapper for sysctl so we don't have to use subprocess'''
+    if isinstance(name, str):
+        name = name.encode('utf-8')
     size = c_uint(0)
     # Find out how big our buffer will be
     libc.sysctlbyname(name, None, byref(size), None, 0)

--- a/facts/monterey_upgrade_supported.py
+++ b/facts/monterey_upgrade_supported.py
@@ -60,6 +60,8 @@ def io_key_string_value(keyname):
 
 def sysctl(name, output_type=str):
     '''Wrapper for sysctl so we don't have to use subprocess'''
+    if isinstance(name, str):
+        name = name.encode('utf-8')
     size = c_uint(0)
     # Find out how big our buffer will be
     libc.sysctlbyname(name, None, byref(size), None, 0)


### PR DESCRIPTION
Prior to this patch, `is_virtual_machine()` was always returning `False` due to `sysctl('machdep.cpu.features')` not properly returning values to detect if the host was a virtual machine (via `'VMM' in cpu_features`)