### PR TITLE
Add system_extensions fact

### DIFF
--- a/facts/system_extensions.py
+++ b/facts/system_extensions.py
@@ -1,0 +1,30 @@
+'''Returns an array of hashtables that represents the current system extensions'''
+
+# Example NSPredicate query to query multiple properties to determine if Symantec endpoint protections extensions are not activated:
+# system_extensions != NULL AND
+# SUBQUERY(
+#     system_extensions,
+#     $s,
+#     $s.state BEGINSWITH 'activated' AND
+#     $s.bundleID IN {'com.broadcom.mes.systemextension', 'com.symantec.mes.systemextension'}
+# ).@count == 0
+
+from __future__ import absolute_import, print_function
+
+import subprocess
+import re
+
+def fact():
+    try:
+        proc = subprocess.Popen(['/usr/bin/systemextensionsctl', 'list'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text="UTF-8")
+        stdout, _ = proc.communicate()
+    except (IOError, OSError):
+        stdout = 'Unknown'
+    
+    regex = re.compile(r"^(\t|\*\t\*|\t\*)\t(?P<teamID>\S*)\t(?P<bundleID>\S*)\s*\((?P<version>\S*)\)\t(?P<name>.*)\b\t\[(?P<state>.*)\]", re.MULTILINE)
+    exts = [match.groupdict() for match in regex.finditer(stdout)]
+    
+    return {'system_extensions': exts}
+
+if __name__ == '__main__':
+    print(fact())


### PR DESCRIPTION
I recently had to transition from one AV product to another.

The AV product I was moving away from (Symantec) has no silent uninstall ability while the system extension is in an activated state.

This fact provides munki with an array of hashtables for each system extension. An example structure for `system_extensions` is as follows:
```
{'system_extensions': [
    {'teamID': 'UBF8T346G9', 'bundleID': 'com.microsoft.wdav.netext', 'version': '101.56.62/101.56.62', 'name': 'Microsoft Defender Network Extension', 'state': 'terminated waiting to uninstall on reboot'},
    {'teamID': 'UBF8T346G9', 'bundleID': 'com.microsoft.wdav.epsext', 'version': '101.56.62/101.56.62', 'name': 'Microsoft Defender Endpoint Security Extension', 'state': 'terminated waiting to uninstall on reboot'},
    {'teamID': 'Y2CCP3S9W7', 'bundleID': 'com.broadcom.mes.systemextension', 'version': '9.1.100/9.1.100', 'name': 'Symantec System Extension', 'state': 'activated waiting for user'}
]}
```